### PR TITLE
refactor: Remove Debug events from Sig

### DIFF
--- a/libraries/Sig.sol
+++ b/libraries/Sig.sol
@@ -5,8 +5,6 @@ import "./ECVerify.sol";
 library Sig {
 
   event Error(string message);
-  event Debug(string key, bytes value);
-  event Debug_bytes32(string key, bytes32 value);
 
   struct t {
     bytes32 hash;
@@ -21,9 +19,6 @@ library Sig {
       mstore(add(c, add(0x20, 32)), b)
     }
     self.hash = keccak256(c);
-    Debug_bytes32('join a', a);
-    Debug_bytes32('join b', b);
-    Debug_bytes32('join c', self.hash);
   }
 
   function param(t memory self, bytes memory value) internal {


### PR DESCRIPTION
Remove the Debug* events from Sig and make it less verbose.
I believe these events were helpful during the initial phases of the development of the library, but now I believe these events are less needed and make the logs harder to read.