### PR TITLE
Updates param function for bool types to match hash generation on b-privacy

### DIFF
--- a/libraries/Sig.sol
+++ b/libraries/Sig.sol
@@ -38,7 +38,8 @@ library Sig {
   }
 
   function param(t memory self, bool value) internal pure {
-    join(self, keccak256(abi.encodePacked(value)));
+    uint boolToInt = value ? 1 : 0;
+    join(self, keccak256(abi.encodePacked(boolToInt)));
   }
 
   function param_string(t memory self, string value) internal pure {


### PR DESCRIPTION
This is to match how b-privacy generates hashes to be signed in ECVerify. Bool types are being transformed to int in order to be used as Buffers in the hash generation:
https://github.com/appliedblockchain/b-privacy-js/blob/master/src/core/to-buffer.js#L27
This allows Sig library to successfully verify signatures produced by B-Privacy when the message being signed includes booleans.